### PR TITLE
Correcting the location of options.locals.body

### DIFF
--- a/lib/hbs.js
+++ b/lib/hbs.js
@@ -14,5 +14,5 @@ var compile = exports.compile = function (source, options) {
 
 exports.render = function (template, options) {
     template = compile(template, options);
-    return template(options, options.blockHelpers);
+    return template(options);
 };


### PR DESCRIPTION
For the life of me I could not get hbs to work within Express (1.0.0). I would get errors resulting from calls to `res.render('some_view')` reading:

500 TypeError: Cannot set property 'body' of undefined  
at /Users/pdokas/local/lib/node/.npm/hbs/0.0.3/package/lib/hbs.js:8:24  
at Object.render (/Users/pdokas/local/lib/node/.npm/hbs/0.0.3/package/lib/hbs.js:20:12)  
at ServerResponse.render (/Users/pdokas/local/lib/node/.npm/express/1.0.0/package/lib/express/view.js:333:22)  
at Object. (/Users/pdokas/Sites/jets/app.js:35:6)

Using node-inspector I dug around figuring out where the `options` object was being altered and found that this was the simplest solutions. Seems the `template` function comping back from `compile()` expects the `options` var in full. I also removed the resultantly-unnecessary passing of blockHelpers as a second param.
