### PR TITLE
Correcting the passing of locals to template()

### DIFF
--- a/lib/hbs.js
+++ b/lib/hbs.js
@@ -13,7 +13,7 @@ var compile = exports.compile = function (source, options) {
 };
 
 exports.render = function (template, options) {
-	var locals = options.locals || (options.locals = {});
+    var locals = options.locals || (options.locals = {});
     template = compile(template, options);
-	return template(locals);
+    return template(locals);
 };


### PR DESCRIPTION
The wrong object seems to be passed right now, resulting in render() not finding any content to render.
