### PR TITLE
Simplified compile/template structure

### DIFF
--- a/lib/hbs.js
+++ b/lib/hbs.js
@@ -2,18 +2,16 @@ var handlebars = require("../support/handlebars/lib/handlebars");
 
 var compile = exports.compile = function (source, options) {
     if (typeof source == 'string') {
-        var template = handlebars.compile(source);
-		return function (options) {
-			// latest Handlebars moved blockHelpers to second parameter
-			return template(options.locals, options.blockHelpers);
-		};
+        return handlebars.compile(source);
     } else {
         return source;
     }
 };
 
 exports.render = function (template, options) {
-    var locals = options.locals || (options.locals = {});
+    var locals = options.locals || (options.locals = {}),
+        blockHelpers = options.blockHelpers || (options.blockHelpers = {});
+    
     template = compile(template, options);
-    return template(locals);
+    return template(locals, blockHelpers);
 };


### PR DESCRIPTION
I think I've got the pathing issues all squared away now, in a way that allows for values as well as null values to pass through while also preventing access to the full `options` object.
