### PR TITLE
Appends extension to layout option if not already provided.

### DIFF
--- a/lib/hbs.js
+++ b/lib/hbs.js
@@ -95,14 +95,19 @@ exports.__express = function(filename, options, cb) {
   }
 
   var view_dir = options.settings.views;
-  var layout_filename = path.join(view_dir, options.layout || 'layout' + extension);
+
+  // Append extension to layout if not already provided
+  var layout_viewname = options.layout || 'layout';
+  if (!path.extname(layout_viewname)) {
+    layout_viewname += extension;
+  }
+
+  var layout_filename = path.join(view_dir, layout_viewname);
 
   var layout_template = cache[layout_filename];
   if (layout_template) {
     return render_with_layout(layout_template, options, cb);
   }
-
-  // TODO check if layout path has .hbs extension
 
   fs.readFile(layout_filename, 'utf8', function(err, str) {
     if (err) {

--- a/test/3.x/app.js
+++ b/test/3.x/app.js
@@ -43,8 +43,8 @@ hbs.registerHelper('list', function(items, fn) {
 
 hbs.registerPartial('link2', '<a href="/people/{{id}}">{{name}}</a>');
 
-app.get('/', function(req, res){
-  res.render('index', {
+function getOptions(options) {
+  var opts = {
     title: 'Express Handlebars Test',
     // basic test
     name: 'Alan',
@@ -74,41 +74,36 @@ app.get('/', function(req, res){
       { "name": "Alan", "id": 1 },
       { "name": "Yehuda", "id": 2 }
     ]
-  });
+  };
+
+  if (!options) return opts;
+
+  for (var opt in options) {
+    opts[opt] = options[opt];
+  }
+
+  return opts;
+}
+
+app.get('/', function(req, res){
+  res.render('index', getOptions());
 });
 
 app.get('/html', function(req, res) {
-  res.render('index.html', {
-    title: 'Express Handlebars Test',
-    // basic test
-    name: 'Alan',
-    hometown: "Somewhere, TX",
-    kids: [{"name": "Jimmy", "age": "12"}, {"name": "Sally", "age": "4"}],
-    // path test
-    person: { "name": "Alan" }, company: {"name": "Rad, Inc." },
-    // escapee test
-    escapee: '<jail>escaped</jail>',
-    // helper test
-    posts: [{url: "/hello-world", body: "Hello World!"}],
-    // helper with string
-    posts2: [{url: "/hello-world", body: "Hello World!"}],
-    // for block helper test
-    people: [
-      {firstName: "Yehuda", lastName: "Katz"},
-      {firstName: "Carl", lastName: "Lerche"},
-      {firstName: "Alan", lastName: "Johnson"}
-    ],
-    people2: [
-      { name: { firstName: "Yehuda", lastName: "Katz" } },
-      { name: { firstName: "Carl", lastName: "Lerche" } },
-      { name: { firstName: "Alan", lastName: "Johnson" } }
-    ],
-    // for partial test
-    people3: [
-      { "name": "Alan", "id": 1 },
-      { "name": "Yehuda", "id": 2 }
-    ]
+  res.render('index.html', getOptions());
+});
+
+app.get('/layouts/:format?', function(req, res) {
+  var template = 'index';
+  var options = getOptions({
+    layout: 'layouts/' + req.query.file
   });
+
+  if (req.params.format) {
+    template += '.' + req.params.format;
+  }
+
+  res.render(template, options);
 });
 
 test('index', function(done) {
@@ -141,4 +136,62 @@ test('html extension', function(done) {
   server.on('close', function() {
     done();
   });
+});
+
+suite('layouts');
+
+test('hbs layout without extension', function(done) {
+  var server = app.listen(3000, function() {
+    var expected = fs.readFileSync(__dirname + '/../fixtures/layouts.html', 'utf8');
+    var testUrl = 'http://localhost:3000/layouts?file=custom_hbs';
+
+    request(testUrl, function(err, res, body) {
+      assert.equal(body, expected);
+      server.close();
+    });
+  });
+
+  server.on('close', done);
+});
+
+test('html layout without extension', function(done) {
+  var server = app.listen(3000, function() {
+    var expected = fs.readFileSync(__dirname + '/../fixtures/layouts.html', 'utf8');
+    var testUrl = 'http://localhost:3000/layouts/html?file=custom_html';
+
+    request(testUrl, function(err, res, body) {
+      assert.equal(body, expected);
+      server.close();
+    });
+  });
+
+  server.on('close', done);
+});
+
+test('hbs layout with extension', function(done) {
+  var server = app.listen(3000, function() {
+    var expected = fs.readFileSync(__dirname + '/../fixtures/layouts.html', 'utf8');
+    var testUrl = 'http://localhost:3000/layouts/hbs?file=custom_hbs.hbs';
+
+    request(testUrl, function(err, res, body) {
+      assert.equal(body, expected);
+      server.close();
+    });
+  });
+
+  server.on('close', done);
+});
+
+test('html layout with extension', function(done) {
+  var server = app.listen(3000, function() {
+    var expected = fs.readFileSync(__dirname + '/../fixtures/layouts.html', 'utf8');
+    var testUrl = 'http://localhost:3000/layouts/html?file=custom_html.html';
+
+    request(testUrl, function(err, res, body) {
+      assert.equal(body, expected);
+      server.close();
+    });
+  });
+
+  server.on('close', done);
 });

--- a/test/3.x/views/layouts/custom_hbs.hbs
+++ b/test/3.x/views/layouts/custom_hbs.hbs
@@ -1,0 +1,10 @@
+<html>
+<head>
+  <title>Custom layout</title>
+  <link rel='stylesheet' href='/stylesheets/style.css'>
+  <script type='text/javascript'></script>
+</head>
+<body>
+{{{body}}}
+</body>
+</html>

--- a/test/3.x/views/layouts/custom_html.html
+++ b/test/3.x/views/layouts/custom_html.html
@@ -1,0 +1,10 @@
+<html>
+<head>
+  <title>Custom layout</title>
+  <link rel='stylesheet' href='/stylesheets/style.css'>
+  <script type='text/javascript'></script>
+</head>
+<body>
+{{{body}}}
+</body>
+</html>

--- a/test/fixtures/layouts.html
+++ b/test/fixtures/layouts.html
@@ -1,0 +1,46 @@
+<html>
+<head>
+  <title>Custom layout</title>
+  <link rel='stylesheet' href='/stylesheets/style.css'>
+  <script type='text/javascript'></script>
+</head>
+<body>
+<h1>Express Handlebars Test</h1>
+<p>Welcome to Express Handlebars Test</p>
+
+<h3>Basic Test</h3>
+<p>
+  Hello, my name is Alan. I am from Somewhere, TX.
+  I have 2 kids:
+</p>
+<ul><li>Jimmy is 12</li><li>Sally is 4</li></ul>
+
+<h3>Path Test</h3>
+<p><code>person.name = </code>
+Alan</p>
+<p><code>../company.name = </code>
+Alan - Rad, Inc.</p>
+
+<h3>Escape Test</h3>
+<table>
+<tr><td>Unescaped:</td><td>&lt;jail&gt;escaped&lt;/jail&gt;</td></tr>
+<tr><td>Escaped:</td><td><jail>escaped</jail></td></tr>
+</table>
+
+<h3>Handlebars Helper Test</h3>
+<ul><li><a href='/hello-world'>Hello World!</a></li></ul>
+
+<h3>Handlebars Helper with String Test</h3>
+<ul><li><a href='/posts/hello-world'>Post</a></li></ul>
+
+<h3>Handlebars Block Helper Test</h3>
+<ul><ul><li>Yehuda Katz</li><li>Carl Lerche</li><li>Alan Johnson</li></ul></ul>
+
+<h3>Handlebars 'with' Block Helper Test</h3>
+<ul><ul><li>Yehuda Katz</li><li>Carl Lerche</li><li>Alan Johnson</li></ul></ul>
+
+<h3>Handlebars Partial Test</h3>
+<ul><li><a href="/people/1">Alan</a></li><li><a href="/people/2">Yehuda</a></li></ul>
+
+</body>
+</html>


### PR DESCRIPTION
I'm not sure if this was the desired approach, but I thought I'd give this a shot.

This patch adds a file extension to the layout filename if not already provided. In the case the extension is not provided, the appended file extension will be consistent with the view template, i.e. `res.render('index.html' { layout: 'custom' });` will render a custom.html layout.
