### PR TITLE
Add cache to exports

### DIFF
--- a/lib/hbs.js
+++ b/lib/hbs.js
@@ -27,7 +27,7 @@ exports.compile = function (str, options) {
 };
 
 // cache for templates, express 3.x doesn't do this for us
-var cache = {};
+var cache = exports.cache = {};
 
 // express 3.x template engine compliance
 exports.__express = function(filename, options, cb) {


### PR DESCRIPTION
I am already using this in the setup I have now. I am using Brunch, which auto compiles Handlebars templates (intended for use in client JS). And since I have that cache available, I wanted to make it available to Node as well..

So I need to be able to access the cache and add compiled templates to it.

Thoughts?
