### PR TITLE
Catch and report errors in the handlebars template

### DIFF
--- a/lib/hbs.js
+++ b/lib/hbs.js
@@ -50,19 +50,17 @@ exports.__express = function(filename, options, cb) {
         return cb(err);
       }
 
+      var locals = options;
+      var template = handlebars.compile(str);
+      if (options.cache) {
+        cache[filename] = template;
+      }
 
       try {
-        var locals = options;
-        var template = handlebars.compile(str);
-        if (options.cache) {
-          cache[filename] = template;
-        }
-
         var res = template(locals);
-
       } catch(templateErr) {
-        templateErr.message += '\n\nFILE: '+ filename;
-        cb(templateErr);
+        templateErr.message = 'FILE: '+ filename +'\n\n'+ templateErr.message;
+        return cb(templateErr);
       }
 
       async.done(function(values) {


### PR DESCRIPTION
This prevents the process from hanging if there is an syntax error in the handlebars template
