### PR TITLE
Support 'view options'

### DIFF
--- a/lib/hbs.js
+++ b/lib/hbs.js
@@ -95,7 +95,9 @@ exports.__express = function(filename, options, cb) {
   }
 
   // options.layout specified and false (don't use layout)
-  if (options.layout !== undefined && !options.layout) {
+  if (options.layout !== undefined && !options.layout
+      || (options.settings && options.settings['view options']
+      && options.settings['view options'].layout === false)) {
     return render_file(options, cb);
   }
 


### PR DESCRIPTION
So I have repeatedly made this fix locally. Most of the express documentation notes that to disable layout on all requests you set the 'view options' value as an object that has layout as false

app.set('view options', {
  layout: false
});

Your code never checks this location and thus requires every request or some middleware to make these changes. I've made this small fix that does just that.
