### PR TITLE
Extend example didn't work with new context.fn change in handlebars, fixed it

### DIFF
--- a/examples/extend/app.js
+++ b/examples/extend/app.js
@@ -18,7 +18,7 @@ hbs.registerHelper('extend', function(name, context) {
         block = blocks[name] = [];
     }
 
-	block.push(context.fn(this));
+	block.push(context.fn(this)); // for older versions of handlebars, use block.push(context(this)); (pre 1.0 I believe)	
 });
 
 hbs.registerHelper('block', function(name) {


### PR DESCRIPTION
added a check for context.fn, if hbs is run against the new version of
handlebars
