### PR TITLE
New version of handlebars uses context.fn() instead of context()

### DIFF
--- a/examples/extend/app.js
+++ b/examples/extend/app.js
@@ -18,7 +18,7 @@ hbs.registerHelper('extend', function(name, context) {
         block = blocks[name] = [];
     }
 
-    block.push(context(this));
+    block.push(context.fn(this)); // for older versions of handlebars, use block.push(context(this));
 });
 
 hbs.registerHelper('block', function(name) {


### PR DESCRIPTION
I did something that messed up the previous pull request.  Here's a new one.
