### PR TITLE
export `create()` to create multiple instances if needed

### DIFF
--- a/lib/hbs.js
+++ b/lib/hbs.js
@@ -6,32 +6,27 @@ var path = require('path');
 // handle async helpers
 var async = require('./async');
 
-// expose handlebars, allows users to use their versions
-// by overriding this early in their apps
-exports.handlebars = require('handlebars');
 
-// express 2.x template engine compliance
-exports.compile = function (str, options) {
-  if (typeof str !== 'string') {
-    return str;
-  }
+var Instance = function() {
+  // expose handlebars, allows users to use their versions
+  // by overriding this early in their apps
 
-  var template = exports.handlebars.compile(str);
-  return function (locals) {
-    return template(locals, {
-      helpers: locals.blockHelpers,
-      partials: null,
-      data: null
-    });
-  };
-};
+  this.handlebars = require('handlebars').create();
 
-// cache for templates, express 3.x doesn't do this for us
-var cache = exports.cache = {};
+  // cache for templates, express 3.x doesn't do this for us
+  this.cache = {};
+
+  this.__express = middleware.bind(this);
+
+  // DEPRECATED, kept for backwards compatibility
+  this.SafeString = this.handlebars.SafeString;
+  this.Utils = this.handlebars.Utils;
+}
 
 // express 3.x template engine compliance
-exports.__express = function(filename, options, cb) {
-  var handlebars = exports.handlebars;
+function middleware(filename, options, cb) {
+  var cache = this.cache;
+  var handlebars = this.handlebars;
 
   // grab extension from filename
   // if we need a layout, we will look for one matching out extension
@@ -141,22 +136,40 @@ exports.__express = function(filename, options, cb) {
   });
 }
 
-/// expose useful methods
+// express 2.x template engine compliance
+Instance.prototype.compile = function (str, options) {
+  if (typeof str !== 'string') {
+    return str;
+  }
 
-exports.registerHelper = function () {
-  exports.handlebars.registerHelper.apply(exports.handlebars, arguments);
+  var template = this.handlebars.compile(str);
+  return function (locals) {
+    return template(locals, {
+      helpers: locals.blockHelpers,
+      partials: null,
+      data: null
+    });
+  };
 };
 
-exports.registerPartial = function () {
-  exports.handlebars.registerPartial.apply(exports.handlebars, arguments);
+// expose useful methods
+
+Instance.prototype.registerHelper = function () {
+  this.handlebars.registerHelper.apply(this.handlebars, arguments);
 };
 
-exports.registerAsyncHelper = function(name, fn) {
-  exports.handlebars.registerHelper(name, function(context) {
+Instance.prototype.registerPartial = function () {
+  this.handlebars.registerPartial.apply(this.handlebars, arguments);
+};
+
+Instance.prototype.registerAsyncHelper = function(name, fn) {
+  this.handlebars.registerHelper(name, function(context) {
     return async.resolve(fn, context);
   });
 };
 
-// DEPRECATED, kept for backwards compatibility
-exports.SafeString = exports.handlebars.SafeString;
-exports.Utils = exports.handlebars.Utils;
+
+module.exports = new Instance();
+module.exports.create = function() {
+    return new Instance();
+};


### PR DESCRIPTION
I need multiple instances of `HBS` in my app. This patch makes that possible.

Usage:

```
var HBS = require("hbs");
var instance1 = HBS.create();
var instance2 = HBS.create();
```

The default pattern of `var instance = HBS` still works.
