### PR TITLE
Add ability to specify custom template extension to registerPartials method

### DIFF
--- a/lib/hbs.js
+++ b/lib/hbs.js
@@ -111,7 +111,7 @@ function middleware(filename, options, cb) {
 
   if (!path.extname(layout_filename)) {
     layout_filename += extension;
-  };
+  }
 
   var layout_template = cache[layout_filename];
   if (layout_template) {
@@ -162,24 +162,36 @@ Instance.prototype.registerPartial = function () {
   this.handlebars.registerPartial.apply(this.handlebars, arguments);
 };
 
-Instance.prototype.registerPartials = function (directory, done) {
+Instance.prototype.registerPartials = function () {
   var handlebars = this.handlebars;
 
+  var directory = arguments[0];
+  var extension, done;
+
+  if(typeof arguments[1] ==='string'){
+    extension = new RegExp("." + arguments[1]);
+    done = arguments[2];
+  } else {
+    extension = null;
+    done = arguments[1];
+  }
+
   var register = function(filepath, done) {
-    var isValidTemplate = /\.(html|hbs)$/.test(filepath);
+    var validExtensions = extension || /\.(html|hbs)$/;
+    var isValidTemplate = validExtensions.test(filepath);
 
     if (!isValidTemplate) {
       return done(null);
     }
 
-    fs.readFile(filepath, 'utf8', function(err, data) {
+    return fs.readFile(filepath, 'utf8', function(err, data) {
+      var templateName;
       if (!err) {
-        var templateName = path.basename(filepath, path.extname(filepath));
+        templateName = path.basename(filepath, path.extname(filepath));
         templateName = templateName.replace(/[ -]/g, '_');
         handlebars.registerPartial(templateName, data);
       }
-
-      done(err);
+      return done(err);
     });
   };
 


### PR DESCRIPTION
Extended `registerPartials` method to allow the usage of custom template filename extensions

Optional argument of `file extension` introduced, while keeping previous usage.

Example:

``` javascript
    hbs.registerPartials('/views/home', 'handlebars');
```
