### PR TITLE
Add ability to expose app and request locals as private variables

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -54,6 +54,29 @@ template-file.html -> {{> template_file}}
 
 See the [handlebars.js](http://github.com/wycats/handlebars.js) README and docs for more information.
 
+## Exposing locals as template data ##
+
+hbs has the ability to expose the application and request locals within any context inside a view. To enable this functionality, simply call the `localsAsTemplateData` method and pass in your Express application instance.
+
+```javascript
+var hbs = require('hbs');
+var express = require('express');
+
+var app = express();
+hbs.localsAsTemplateData(app);
+
+app.locals.foo = "bar";
+```
+
+The local data can then be accessed using the `@property` syntax:
+
+```
+top level: {{@foo}}
+{{#each items}}
+  {{label}}: {{@foo}}
+{{/each}}
+```
+
 ## handlebars ##
 
 The handlebars require used by hbs can be accessed via the `handlebars` property on the `hbs` module.

--- a/lib/hbs.js
+++ b/lib/hbs.js
@@ -50,7 +50,9 @@ function middleware(filename, options, cb) {
       }
 
       try {
-        var res = template(locals);
+        var data = locals.__hbsLocals;
+        delete locals.__hbsLocals;
+        var res = template(locals, { data: data });
         async.done(function(values) {
           Object.keys(values).forEach(function(id) {
             res = res.replace(id, values[id]);
@@ -189,6 +191,29 @@ Instance.prototype.registerAsyncHelper = function(name, fn) {
   this.handlebars.registerHelper(name, function(context) {
     return async.resolve(fn, context);
   });
+};
+
+Instance.prototype.localsAsTemplateData = function(app) {
+  app.render = (function(render) {
+    return function(view, options, callback) {
+      if (typeof options === "function") {
+        callback = options;
+        options = {};
+      }
+
+      // Mix response.locals (options._locals) with app.locals (this.locals)
+      options._locals = options._locals || {};
+      for (var key in this.locals) {
+        options._locals[key] = this.locals[key];
+      }
+
+      // Store the data again, so that we can differentiate this data from
+      // the data passed to response.data() when we're inside the view
+      options._locals.__hbsLocals = options._locals;
+
+      return render.call(this, view, options, callback);
+    };
+  })(app.render);
 };
 
 module.exports = new Instance();

--- a/test/3.x/app.js
+++ b/test/3.x/app.js
@@ -44,6 +44,9 @@ hbs.registerHelper('list', function(items, context) {
 hbs.registerPartial('link2', '<a href="/people/{{id}}">{{name}}</a>');
 hbs.registerPartials(__dirname + '/views/partials');
 
+// expose app and response locals in views
+hbs.localsAsTemplateData(app);
+
 app.get('/', function(req, res){
   res.render('index', {
     title: 'Express Handlebars Test',
@@ -122,6 +125,14 @@ app.get('/partials', function(req, res) {
 
 app.get('/escape', function(req, res) {
   res.render('escape', { title: 'foobar', layout: false });
+});
+
+app.get('/locals', function(req, res) {
+  res.locals.person = 'Alan';
+  res.render('locals', {
+    layout: false,
+    kids: [{ name: 'Jimmy' }, { name: 'Sally' }],
+  });
 });
 
 test('index', function(done) {
@@ -204,3 +215,18 @@ test('escape for frontend', function(done) {
   });
 });
 
+test('response locals', function(done) {
+  var server = app.listen(3000, function() {
+
+    var expected = fs.readFileSync(__dirname + '/../fixtures/locals.html', 'utf8');
+
+    request('http://localhost:3000/locals', function(err, res, body) {
+      assert.equal(body, expected);
+      server.close();
+    });
+  });
+
+  server.on('close', function() {
+    done();
+  });
+});

--- a/test/3.x/views/locals.hbs
+++ b/test/3.x/views/locals.hbs
@@ -1,0 +1,3 @@
+{{#each kids}}
+{{@person}} has a kid named {{name}}.
+{{/each}}

--- a/test/fixtures/locals.html
+++ b/test/fixtures/locals.html
@@ -1,0 +1,5 @@
+
+Alan has a kid named Jimmy.
+
+Alan has a kid named Sally.
+


### PR DESCRIPTION
Fixes #57

I went ahead and implemented this as `hbs.provideLocals()`. Let me know if you want a different API and I'll change it. I can also add a full example in the `examples` directory if you'd like.

I wrote a test, but it's being marked as a failure even though there's no visible difference.
