### PR TITLE
Register partials on a windows machine fails

### DIFF
--- a/lib/hbs.js
+++ b/lib/hbs.js
@@ -171,7 +171,7 @@ Instance.prototype.registerPartials = function (directory, done) {
       if (!err) {
         var ext = path.extname(filepath);
         var templateName = path.relative(directory, filepath)
-          .slice(0, -(ext.length)).replace(/[ -]/g, '_');
+          .slice(0, -(ext.length)).replace(/[ -]/g, '_').replace('\\', '/');
         handlebars.registerPartial(templateName, data);
       }
 


### PR DESCRIPTION
Hi,

I am using hbs 2.6.0 on a windows 7 machine. I have a partials directory with sub directories. On my windows machine partials are registered with an "\". For example "tables\editable_datatable". Where i would expect "tables/editable_datatable". 

I made a fix for this which replaces all "\" with "/". This works as expected on windows 7. Tomorrow i will have a change to test on a linux environment. 
