### PR TITLE
Allow helpers to be created per request

### DIFF
--- a/lib/hbs.js
+++ b/lib/hbs.js
@@ -35,7 +35,9 @@ function middleware(filename, options, cb) {
     // cached?
     var template = cache[filename];
     if (template) {
-      return cb(null, template(locals));
+      return cb(null, template(locals, {
+        helpers: locals.helpers
+      }));
     }
 
     fs.readFile(filename, 'utf8', function(err, str){
@@ -52,7 +54,10 @@ function middleware(filename, options, cb) {
       try {
         var data = locals.__hbsLocals;
         delete locals.__hbsLocals;
-        var res = template(locals, { data: data });
+        var res = template(locals, {
+          data: data,
+          helpers: locals.helpers
+        });
         async.done(function(values) {
           Object.keys(values).forEach(function(id) {
             res = res.replace(id, values[id]);
@@ -77,7 +82,9 @@ function middleware(filename, options, cb) {
       var locals = options;
       locals.body = str;
 
-      var res = template(locals);
+      var res = template(locals, {
+        helpers: locals.helpers
+      });
       async.done(function(values) {
         Object.keys(values).forEach(function(id) {
           res = res.replace(id, values[id]);


### PR DESCRIPTION
There are some helpers that I need to register on each request in order to access `req` in them. This pull request allows helpers to be registered by passing a `helpers` object in the render options when the Handlebars template is compiled.
#### Example

``` javascript
res.render('page', {
  helpers: {
    foo: function() { return 'bar' }
  }
});
```

You can register a helper in middleware for every request to access `req`:

``` javascript
app.use(function(req, res, next) {
  res.locals.helpers = {
    translate: function(key) {
      return req.i18n.t(key);
    }
  };
});
```
