### PR TITLE
I found a bug about asynchronous helper and fixed it

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,7 @@
 unreleased
 ==========
 
+  * Fix async helpers not working when cache enabled
   * deps: handlebars@4.1.2
   * deps: walk@2.3.14
 

--- a/lib/hbs.js
+++ b/lib/hbs.js
@@ -46,7 +46,16 @@ function middleware(filename, options, cb) {
     // cached?
     var template = cache[filename];
     if (template) {
-      return cb(null, template(locals, handlebarsOpts));
+      var res = template(locals, handlebarsOpts)
+      self.async.done(function (values) {
+        Object.keys(values).forEach(function (id) {
+          res = res.replace(id, values[id])
+        })
+
+        cb(null, res)
+      })
+
+      return
     }
 
     fs.readFile(filename, 'utf8', function(err, str){

--- a/test/4.x/async_helpers.js
+++ b/test/4.x/async_helpers.js
@@ -27,6 +27,7 @@ before(function () {
   app.engine('hbs', hbs.__express)
 
   // set the view engine to use handlebars
+  app.set('view cache', true)
   app.set('view engine', 'hbs')
   app.set('views', path.join(__dirname, 'views'))
 
@@ -34,10 +35,11 @@ before(function () {
 
   // value for async helper
   // it will be called a few times from the template
+  var indx = 0
   var vals = ['foo', 'bar', 'baz']
   hbs.registerAsyncHelper('async', function (context, cb) {
     process.nextTick(function () {
-      cb(vals.shift())
+      cb(vals[indx++ % 3])
     })
   })
 
@@ -89,6 +91,13 @@ test('async', function(done) {
     .expect(fs.readFileSync(path.join(FIXTURES_DIR, 'fake-async.html'), 'utf8'))
     .end(done)
 });
+
+test('cached', function (done) {
+  request(app)
+    .get('/')
+    .expect(fs.readFileSync(path.join(FIXTURES_DIR, 'async.html'), 'utf8'))
+    .end(done)
+})
 
 test('async-with-params', function(done) {
   request(app)


### PR DESCRIPTION
### bug description
If a file was cached, asynchronous helpers will just render a **random string** on the page.
