### PR TITLE
Handle exceptions with cached templates

### DIFF
--- a/lib/hbs.js
+++ b/lib/hbs.js
@@ -46,7 +46,15 @@ function middleware(filename, options, cb) {
     // cached?
     var template = cache[filename];
     if (template) {
-      return cb(null, template(locals, handlebarsOpts));
+      var res, err = null;
+      try {
+        res = template(locals, handlebarsOpts);
+      } catch (e) {
+        err = e;
+        err.message = filename + ': ' + err.message;
+      }
+
+      return cb(err, res);
     }
 
     fs.readFile(filename, 'utf8', function(err, str){


### PR DESCRIPTION
We ran into an issue where errors thrown by cached templates kill the application in such a way that it cannot recover. The process itself is corrupted in such a way that spawning new workers (we’re using lthe `cluster` module) resulted in those new workers dying immediately. @shawnsi found that this seems to be the case for Node.js in Linux (CentOS), yet not in macOS.

After a lot of debugging, we identified `hbs` as the root cause, as it does not handle errors stemming from cached templates the way it handles them for newly-loaded templates. We haven’t delved too deeply into why this is a problem in one platform and not others.

This PR adds error handling for cached templates similar to the way errors are handled for non-cached templates. We’ve found that errors thrown at render time from a bad template or a template invoked with bad data are handle consistently with this fix, and that the application remains healthy and stable.