### PR TITLE
deps: handlebars@4.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lib": "./lib"
   },
   "dependencies": {
-    "handlebars": "4.0.14",
+    "handlebars": "4.1.2",
     "walk": "2.3.9"
   },
   "devDependencies": {


### PR DESCRIPTION
Pulls in fix for [RCE vulnerability](https://github.com/wycats/handlebars.js/commit/edc6220d51139b32c28e51641fadad59a543ae57) in `handlebars<4.1.0`.