### PR TITLE
Fix  security alert has occurred.

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,13 +12,13 @@
     "lib": "./lib"
   },
   "dependencies": {
-    "handlebars": "4.0.14",
+    "handlebars": ">=4.1.0",
     "walk": "2.3.9"
   },
   "devDependencies": {
     "istanbul": "0.4.5",
-    "mocha": "1.21.5",
-    "supertest": "1.1.0"
+    "mocha": "^6.1.4",
+    "supertest": "^4.0.2"
   },
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
The `npm install` command emits the following error: 

```
$ npm install
npm WARN deprecated istanbul@0.4.5: This module is no longer maintained, try this instead:
npm WARN deprecated   npm i nyc
npm WARN deprecated Visit https://istanbul.js.org/integrations for other alternatives.
npm WARN deprecated superagent@1.3.0: Please note that v5.0.1+ of superagent removes User-Agent header by default, therefore you may need to add it yourself (e.g. GitHub blocks requests without a User-Agent header).  This notice will go away with v5.0.2+ once it is released.
npm WARN deprecated jade@0.26.3: Jade has been renamed to pug, please install the latest version of pug instead of jade
npm WARN deprecated minimatch@0.2.14: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
npm WARN deprecated graceful-fs@2.0.3: please upgrade to graceful-fs 4 for compatibility with current and future versions of Node.js
npm notice created a lockfile as package-lock.json. You should commit this file.
added 88 packages from 160 contributors and audited 114 packages in 3.748s
found 8 vulnerabilities (3 low, 3 moderate, 1 high, 1 critical)
  run `npm audit fix` to fix them, or `npm audit` for details
```

These errors were resolved with the `npm audit --force` command, and I confirmed that the test passed.