### PR TITLE
Update handlebars version

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lib": "./lib"
   },
   "dependencies": {
-    "handlebars": "4.0.14",
+    "handlebars": "4.1.2",
     "walk": "2.3.9"
   },
   "devDependencies": {


### PR DESCRIPTION
I have created a fork that updates the version of the handlebars dependency.  When using the version of hbs that depends on the old version of handlebars, I received notices that said the handlebars code contained vulnerabilities and that the handlebars version in use should be updated.