### PR TITLE
Fix handlebars upstream vulnerability

### DIFF
--- a/lib/hbs.js
+++ b/lib/hbs.js
@@ -69,8 +69,7 @@ function middleware(filename, options, cb) {
           cb(null, res);
         });
       } catch (err) {
-        err.message = filename + ': ' + err.message;
-        cb(err);
+        cb(new Error(filename + ': ' + err.message));
       }
     });
   }

--- a/package.json
+++ b/package.json
@@ -12,13 +12,13 @@
     "lib": "./lib"
   },
   "dependencies": {
-    "handlebars": "4.0.14",
-    "walk": "2.3.9"
+    "handlebars": "^4.3.1",
+    "walk": "^2.3.9"
   },
   "devDependencies": {
-    "istanbul": "0.4.5",
-    "mocha": "1.21.5",
-    "supertest": "1.1.0"
+    "istanbul": "^0.4.5",
+    "mocha": "^6.2.0",
+    "supertest": "^1.1.0"
   },
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
This fixes the upstream prototype pollution [vulnerability](https://snyk.io/vuln/npm:handlebars) in handlebars that was fixed in handlebars 4.3.0. Similar to #175 but with tests passing.

Test result against Node.js v10.16.0:

```
  ✓ express 3.x index: 42ms
  ✓ express 3.x partials: 7ms
  ✓ express 3.x html extension: 15ms
  ✓ express 3.x syntax error: 3ms
  ✓ express 3.x escape for frontend: 3ms
  ✓ express 3.x response locals: 3ms
  ✓ express 3.x response locals cached: 4ms
  ✓ express 3.x response globals: 5ms
  ✓ express 3.x app.render: 2ms
  ✓ express 3.x async helpers index: 4ms
  ✓ express 3.x async helpers async: 3ms
  ✓ express 3.x view engine index: 3ms
  ✓ express 3.x view engine index w/layout: 2ms
  ✓ express 3.x no layout index: 2ms
  ✓ express 3.x no layout index w/layout: 3ms
  ✓ express 3.x no layout index layout cache: 2ms
  ✓ express 4.x index: 12ms
  ✓ express 4.x partials: 3ms
  ✓ express 4.x html extension: 8ms
  ✓ express 4.x syntax error: 3ms
  ✓ express 4.x escape for frontend: 3ms
  ✓ express 4.x response locals: 3ms
  ✓ express 4.x response locals cached: 12ms
  ✓ express 4.x response globals: 4ms
  ✓ express 4.x multiple views directories: 3ms
  ✓ express 4.x app.render: 2ms
  ✓ express 4.x async helpers index: 4ms
  ✓ express 4.x async helpers async: 2ms
  ✓ express 4.x async helpers async-with-params: 2ms
  ✓ express 4.x view engine index: 2ms
  ✓ express 4.x view engine index w/layout: 3ms
  ✓ express 4.x no layout index: 2ms
  ✓ express 4.x no layout index w/layout: 3ms
  ✓ express 4.x no layout index layout cache: 2ms

  34 passing (3s)

=============================================================================
Writing coverage object [/Users/janjongboom/repos/hbs/coverage/coverage.json]
Writing coverage reports at [/Users/janjongboom/repos/hbs/coverage]
=============================================================================

=============================== Coverage summary ===============================
Statements   : 89.66% ( 156/174 )
Branches     : 73.13% ( 49/67 )
Functions    : 92.31% ( 36/39 )
Lines        : 89.66% ( 156/174 )
```

The patch in lib/hbs.js is not strictly related to this patch, but is to get the tests running in the current version of Node.js. Master tests are also broken against Node v10.