### PR TITLE
resolve npm audit report for mocha

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "istanbul": "0.4.5",
-    "mocha": "1.21.5",
+    "mocha": "~6.2.0",
     "supertest": "1.1.0"
   },
   "license": "MIT",


### PR DESCRIPTION
Update mocha to resolve NPM security reports.

mocha 4.0.0 would have been sufficient, but we might as well keep up with the latest major version now, as this doesn't appear to break anything, and will help us to resolve further security warnings much faster.