### PR TITLE
resolve npm reports on supertest security risk

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "devDependencies": {
     "istanbul": "0.4.5",
     "mocha": "1.21.5",
-    "supertest": "1.1.0"
+    "supertest": "~4.0.2"
   },
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
Resolve NPM security reports on supertest dependency.

supertest 3.0.0 would have been sufficient, but we might as well keep up with the latest major release, in order to resolve further security warnings more quickly.