### PR TITLE
Fix asyncHelper missing locals context

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,8 @@
+unreleased
+==========
+
+  * Fix function context in async helpers
+
 4.1.2 / 2021-04-15
 ==================
 

--- a/lib/hbs.js
+++ b/lib/hbs.js
@@ -254,7 +254,7 @@ Instance.prototype.registerPartials = function (directory, done) {
 Instance.prototype.registerAsyncHelper = function(name, fn) {
   var self = this;
   self.handlebars.registerHelper(name, function() {
-    return self.async.resolve(fn, arguments);
+    return self.async.resolve(fn.bind(this), arguments)
   });
 };
 

--- a/test/3.x/async_helpers.js
+++ b/test/3.x/async_helpers.js
@@ -36,8 +36,18 @@ before(function () {
   // it will be called a few times from the template
   var vals = ['foo', 'bar', 'baz']
   hbs.registerAsyncHelper('async', function (context, cb) {
+    var prefix = this.prefix || ''
+
     process.nextTick(function () {
-      cb(vals.shift())
+      cb(prefix + vals.shift())
+    })
+  })
+
+  hbs.registerAsyncHelper('async-with-context', function (context, cb) {
+    var originalUrl = this.originalUrl
+
+    process.nextTick(function () {
+      cb('originalUrl: ' + originalUrl)
     })
   })
 
@@ -52,7 +62,8 @@ before(function () {
 
   app.get('/', function (req, res) {
     res.render('async', {
-      layout: false
+      layout: false,
+      prefix: '* '
     })
   })
 

--- a/test/3.x/views/async-with-context.hbs
+++ b/test/3.x/views/async-with-context.hbs
@@ -1,0 +1,1 @@
+{{async-with-context}}

--- a/test/4.x/async_helpers.js
+++ b/test/4.x/async_helpers.js
@@ -38,8 +38,10 @@ before(function () {
   var indx = 0
   var vals = ['foo', 'bar', 'baz']
   hbs.registerAsyncHelper('async', function (context, cb) {
+    var prefix = this.prefix || ''
+
     process.nextTick(function () {
-      cb(vals[indx++ % 3])
+      cb(prefix + vals[indx++ % 3])
     })
   })
 
@@ -56,6 +58,15 @@ before(function () {
     })
   })
 
+  // access req data from res.locals
+  hbs.registerAsyncHelper('async-with-context', function (context, cb) {
+    var originalUrl = this.originalUrl
+
+    process.nextTick(function () {
+      cb('originalUrl: ' + originalUrl)
+    })
+  })
+
   var count = 0
 
   // fake async helper, returns immediately
@@ -67,7 +78,8 @@ before(function () {
 
   app.get('/', function (req, res) {
     res.render('async', {
-      layout: false
+      layout: false,
+      prefix: '* '
     })
   })
 

--- a/test/4.x/views/async-with-context.hbs
+++ b/test/4.x/views/async-with-context.hbs
@@ -1,0 +1,1 @@
+{{async-with-context}}

--- a/test/fixtures/async.html
+++ b/test/fixtures/async.html
@@ -1,3 +1,3 @@
-foo
-bar
-baz
+* foo
+* bar
+* baz


### PR DESCRIPTION
Since normal helper allow exposing locals to template data, but asyncHelper can't, here's a quick fix to bind locals context to temlate.

```js
var hbs = require('hbs');
var app = express();
app.set('view engine', 'hbs');

hbs.registerAsyncHelper('link', function(type, options, callback) {
  callback('<a href="#">' + this.originalUrl + '</a>');
});

app.use(function (req, res, next) {
  res.locals.originalUrl = req.originalUrl;
  next()
};
```

Related issue: https://github.com/pillarjs/hbs/issues/138#issuecomment-465410833