### PR TITLE
fix(ci): pins nyc to version 13.3.0 for node v8 step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
 
         - name: Node.js 8.x
           node-version: "8.17"
-          npm-i: mocha@7.2.0
+          npm-i: mocha@7.2.0 nyc@13.3.0
 
         - name: Node.js 10.x
           node-version: "10.24"


### PR DESCRIPTION
I believe the error was using an incompatible `nyc` version (or not removing it as in the previous steps) for the `Node.js 8.x` step of the matrix that uses Node version 8.17.

I've pinned the last `nyc` compatible version for Node v8.17 for that step.

You can see the passing workflows [here](https://github.com/mfdebian/hbs/actions/runs/15659381546).

Closes #222 