### PR TITLE
feat(lib): updates code to use es6 and promise based async 

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,6 +1,12 @@
 root: true
 extends:
   - plugin:markdown/recommended
+env:
+  es6: true
+  node: true
+parserOptions:
+  ecmaVersion: 2017
+  sourceType: script
 plugins:
   - markdown
 overrides:
@@ -8,11 +14,11 @@ overrides:
     processor: 'markdown/markdown'
 rules:
   eol-last: error
-  eqeqeq: ["error", "always", { "null": "ignore" }]
+  eqeqeq: ['error', 'always', { 'null': 'ignore' }]
   no-console: error
   no-mixed-spaces-and-tabs: error
-  no-multiple-empty-lines: ["error", { "max": 1, "maxEOF": 0 }]
+  no-multiple-empty-lines: ['error', { 'max': 1, 'maxEOF': 0 }]
   no-path-concat: error
-  no-redeclare: ["error", { "builtinGlobals": false }]
+  no-redeclare: ['error', { 'builtinGlobals': false }]
   no-trailing-spaces: error
-  one-var: ["error", { "initialized": "never" }]
+  one-var: ['error', { 'initialized': 'never' }]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,10 +35,11 @@ jobs:
 
         - name: Node.js 10.x
           node-version: "10.24"
-          npm-i: mocha@8.3.2
+          npm-i: mocha@8.3.2 nyc@14.1.1
 
         - name: Node.js 12.x
           node-version: "12.22"
+          npm-i: nyc@14.1.1
 
         - name: Node.js 14.x
           node-version: "14.18"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,6 @@ jobs:
     strategy:
       matrix:
         name:
-        - Node.js 0.8
-        - Node.js 0.10
-        - Node.js 4.x
         - Node.js 6.x
         - Node.js 8.x
         - Node.js 10.x
@@ -27,21 +24,6 @@ jobs:
         - Node.js 16.x
 
         include:
-        - name: Node.js 0.8
-          node-version: "0.8"
-          npm-i: mocha@2.5.3 supertest@1.1.0
-          npm-rm: nyc
-
-        - name: Node.js 0.10
-          node-version: "0.10"
-          npm-i: mocha@3.5.3 supertest@2.0.0
-          npm-rm: nyc
-
-        - name: Node.js 4.x
-          node-version: "4.9"
-          npm-i: mocha@5.2.0 supertest@3.4.2
-          npm-rm: nyc
-
         - name: Node.js 6.x
           node-version: "6.17"
           npm-i: mocha@6.2.2

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ app.engine('html', require('hbs').__express);
 hbs exposes the `registerHelper` and `registerPartial` method from handlebars.
 
 ```javascript
-var hbs = require('hbs');
+const hbs = require('hbs');
 
 hbs.registerHelper('helper_name', function (options) { return 'helper value'; });
 hbs.registerPartial('partial_name', 'partial value');
@@ -48,7 +48,7 @@ hbs.registerPartial('partial_name', 'partial value');
 For convenience, `registerPartials` provides a quick way to load all partials from a specific directory:
 
 ```javascript
-var hbs = require('hbs');
+const hbs = require('hbs');
 
 hbs.registerPartials(__dirname + '/views/partials', function (err) {});
 ```
@@ -68,7 +68,7 @@ information.
 The way the file is renamed to a partial name can be adjusted by providing a `rename` option. The function will receive the file path relative to the registered directory and without the file extension. If the returned value contains any whitespace, those characters are replaced with a corresponding underscore character.
 
 ```js
-var hbs = require('hbs')
+const hbs = require('hbs')
 
 hbs.registerPartials(path.join(__dirname, '/views/partials'), {
   rename: function (name) {
@@ -85,10 +85,10 @@ hbs.registerPartials(path.join(__dirname, '/views/partials'), {
 hbs has the ability to expose the application and request locals within any context inside a view. To enable this functionality, simply call the `localsAsTemplateData` method and pass in your Express application instance.
 
 ```javascript
-var hbs = require('hbs');
-var express = require('express');
+const hbs = require('hbs');
+const express = require('express');
 
-var app = express();
+const app = express();
 hbs.localsAsTemplateData(app);
 
 app.locals.foo = "bar";
@@ -121,10 +121,10 @@ hbs.handlebars === require('handlebars');
 You can create isolated instances of hbs using the `create()` function on the module object.
 
 ```
-var hbs = require('hbs');
+const hbs = require('hbs');
 
-var instance1 = hbs.create();
-var instance2 = hbs.create();
+const instance1 = hbs.create();
+const instance2 = hbs.create();
 
 app.engine('html', instance1.__express);
 app.engine('hbs', instance2.__express);

--- a/examples/extend/app.js
+++ b/examples/extend/app.js
@@ -1,8 +1,8 @@
-var express = require('express');
-var hbs = require('hbs');
-var path = require('path')
+const express = require('express');
+const hbs = require('hbs');
+const path = require('path')
 
-var app = express();
+const app = express();
 
 // set the view engine to use handlebars
 app.set('view engine', 'hbs');
@@ -10,10 +10,10 @@ app.set('views', path.join(__dirname, 'views'))
 
 app.use(express.static(path.join(__dirname, 'public')))
 
-var blocks = {};
+const blocks = {};
 
 hbs.registerHelper('extend', function(name, context) {
-    var block = blocks[name];
+    const block = blocks[name];
     if (!block) {
         block = blocks[name] = [];
     }
@@ -22,7 +22,7 @@ hbs.registerHelper('extend', function(name, context) {
 });
 
 hbs.registerHelper('block', function(name) {
-    var val = (blocks[name] || []).join('\n');
+    const val = (blocks[name] || []).join('\n');
 
     // clear the block
     blocks[name] = [];

--- a/examples/partial/app.js
+++ b/examples/partial/app.js
@@ -1,11 +1,11 @@
-var fs = require('fs');
-var path = require('path')
+const fs = require('fs');
+const path = require('path')
 
 // 3rd party
-var express = require('express');
-var hbs = require('hbs');
+const express = require('express');
+const hbs = require('hbs');
 
-var app = express();
+const app = express();
 
 hbs.registerPartial('partial', fs.readFileSync(path.join(__dirname, 'views', 'partial.hbs'), 'utf8'))
 hbs.registerPartials(path.join(__dirname, 'views', 'partials'))

--- a/lib/async.js
+++ b/lib/async.js
@@ -5,7 +5,7 @@ function Waiter() {
         return new Waiter();
     }
 
-    var self = this;
+    const self = this;
 
     // found values
     self.values = {};
@@ -19,13 +19,13 @@ function Waiter() {
 };
 
 Waiter.prototype.wait = function() {
-    var self = this;
+    const self = this;
     ++self.count;
 };
 
 // resolve the promise
 Waiter.prototype.resolve = function(name, val) {
-    var self = this;
+    const self = this;
 
     self.values[name] = val;
 
@@ -43,7 +43,7 @@ Waiter.prototype.resolve = function(name, val) {
 // sets the done callback for the waiter
 // notifies when the promise is complete
 Waiter.prototype.done = function(fn) {
-    var self = this;
+    const self = this;
 
     self.callback = fn;
     if (self.resolved) {
@@ -51,11 +51,11 @@ Waiter.prototype.done = function(fn) {
     }
 };
 
-var alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz_';
+const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz_';
 
-var gen_id = function() {
-    var res = '';
-    for (var i=0 ; i<8 ; ++i) {
+const gen_id = function() {
+    let res = '';
+    for (let i=0 ; i<8 ; ++i) {
         res += alphabet[Math.floor(Math.random() * alphabet.length)];
     }
 
@@ -65,9 +65,9 @@ var gen_id = function() {
 module.exports = function() {
     // baton which contains the current
     // set of deferreds
-    var waiter;
+    let waiter;
 
-    var obj = Object.create(null);
+    const obj = Object.create(null);
     obj.done = function done(fn) {
         // no async things called
         if (!waiter) {
@@ -86,9 +86,9 @@ module.exports = function() {
             waiter = new Waiter();
         }
 
-        var id = '__' + gen_id() + '__';
+        const id = '__' + gen_id() + '__';
 
-        var cur_waiter = waiter;
+        const cur_waiter = waiter;
         waiter.wait();
 
         args = [].slice.call(args);

--- a/lib/async.js
+++ b/lib/async.js
@@ -1,56 +1,3 @@
-/// provides the async helper functionality
-
-function Waiter() {
-    if (!(this instanceof Waiter)) {
-        return new Waiter();
-    }
-
-    const self = this;
-
-    // found values
-    self.values = {};
-
-    // callback when done
-    self.callback = null;
-
-    self.resolved = false;
-
-    self.count = 0;
-};
-
-Waiter.prototype.wait = function() {
-    const self = this;
-    ++self.count;
-};
-
-// resolve the promise
-Waiter.prototype.resolve = function(name, val) {
-    const self = this;
-
-    self.values[name] = val;
-
-    // done with all items
-    if (--self.count === 0) {
-        self.resolved = true;
-
-        // we may not have a done callback yet
-        if (self.callback) {
-            self.callback(self.values);
-        }
-    }
-};
-
-// sets the done callback for the waiter
-// notifies when the promise is complete
-Waiter.prototype.done = function(fn) {
-    const self = this;
-
-    self.callback = fn;
-    if (self.resolved) {
-        fn(self.values);
-    }
-};
-
 const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz_';
 
 const gen_id = function() {
@@ -63,44 +10,74 @@ const gen_id = function() {
 };
 
 module.exports = function() {
-    // baton which contains the current
-    // set of deferreds
-    let waiter;
+    // map to store pending promises by their placeholder IDs
+    const operations = new Map();
 
     const obj = Object.create(null);
-    obj.done = function done(fn) {
-        // no async things called
-        if (!waiter) {
-            return fn({});
-        }
 
-        waiter.done(fn);
-
-        // clear the waiter for the next template
-        waiter = undefined;
-    };
-
-    obj.resolve = function resolve(fn, args) {
-        // we want to do async things, need a waiter for that
-        if (!waiter) {
-            waiter = new Waiter();
-        }
-
+    // register an async operation and return a placeholder ID
+    obj.resolve = function resolve(fn) {
+        const args = Array.prototype.slice.call(arguments, 1);
         const id = '__' + gen_id() + '__';
 
-        const cur_waiter = waiter;
-        waiter.wait();
+        const promise = new Promise(function (resolve, reject) {
+            // add callback as last argument
+            const callback = function (result, error) {
+                if (error) {
+                    reject(error);
+                } else {
+                    resolve(result);
+                }
+            };
 
-        args = [].slice.call(args);
-        args.push(function(res) {
-            cur_waiter.resolve(id, res);
-        })
+            try {
+                fn.apply(null, args.concat([callback]));
+            } catch (err) {
+                reject(err);
+            }
+        });
 
-        fn.apply(null, args);
-
-        // return the id placeholder
-        // this will be replaced later
+        operations.set(id, promise);
         return id;
+    };
+
+    // wait for all operations to complete and return results mapped by ID
+    obj.done = function done() {
+        if (operations.size === 0) {
+            return Promise.resolve({});
+        }
+
+        const entries = Array.from(operations.entries());
+        const promises = entries.map(function (entry) {
+            return entry[1];
+        });
+
+        return Promise.all(promises)
+            .then(function (results) {
+                const values = {};
+                entries.forEach(function (entry, index) {
+                    values[entry[0]] = results[index]; // entry[0] is the id
+                });
+
+                // clear operations after successful completion
+                operations.clear();
+                return values;
+            })
+            .catch(function (error) {
+                // clear operations even on error
+                operations.clear();
+                throw error;
+            });
+    };
+
+    // check if there are pending operations
+    obj.hasPending = function hasPending() {
+        return operations.size > 0;
+    };
+
+    // clear all pending operations
+    obj.clear = function clear() {
+        operations.clear();
     };
 
     return obj;

--- a/lib/hbs.js
+++ b/lib/hbs.js
@@ -21,7 +21,7 @@ function Instance(handlebars) {
   self.__express = middleware.bind(this);
 
   // queue for partials registration
-  self._queue = null
+  self._queue = null;
 
   // DEPRECATED, kept for backwards compatibility
   self.SafeString = this.handlebars.SafeString;
@@ -49,12 +49,34 @@ function middleware(filename, options, cb) {
   // Default handlebars runtime options
   const handlebarsOpts = {
     allowProtoMethodsByDefault: true,
-    allowProtoPropertiesByDefault: true
-  }
+    allowProtoPropertiesByDefault: true,
+  };
 
   // If passing the locals as data, create the handlebars options object now
   if (self.__localsAsData) {
-    handlebarsOpts.data = options._locals
+    handlebarsOpts.data = options._locals;
+  }
+
+  // Helper function to process async placeholders
+  function processAsyncResults(template, cb) {
+    if (!self.async.hasPending()) {
+      return cb(null, template);
+    }
+
+    self.async
+      .done()
+      .then(function (values) {
+        let res = template;
+
+        Object.keys(values).forEach(function (id) {
+          res = res.replace(new RegExp(id, 'g'), values[id]);
+        });
+
+        cb(null, res);
+      })
+      .catch(function (error) {
+        cb(error);
+      });
   }
 
   // render the original file
@@ -64,22 +86,23 @@ function middleware(filename, options, cb) {
     const template = cache[filename];
     if (template) {
       try {
-        let res = template(locals, handlebarsOpts)
-        self.async.done(function (values) {
-          Object.keys(values).forEach(function (id) {
-            res = res.replace(id, values[id])
-          })
+        const res = template(locals, handlebarsOpts);
 
-          cb(null, res)
-        })
+        // Handle async operations
+        processAsyncResults(res, function (err, processedRes) {
+          if (err) {
+            return cb(prependFilenameToError(filename, err));
+          }
+          cb(null, processedRes);
+        });
       } catch (err) {
-        cb(prependFilenameToError(filename, err))
+        cb(prependFilenameToError(filename, err));
       }
 
-      return
+      return;
     }
 
-    fs.readFile(filename, 'utf8', function(err, str){
+    fs.readFile(filename, 'utf8', function (err, str){
       if (err) {
         return cb(err);
       }
@@ -90,23 +113,24 @@ function middleware(filename, options, cb) {
       }
 
       try {
-        let res = template(locals, handlebarsOpts);
-        self.async.done(function(values) {
-          Object.keys(values).forEach(function(id) {
-            res = res.replace(id, values[id]);
-          });
+        const res = template(locals, handlebarsOpts);
 
-          cb(null, res);
+        // handle async operations
+        processAsyncResults(res, function (err, processedRes) {
+          if (err) {
+            return cb(prependFilenameToError(filename, err));
+          }
+          cb(null, processedRes);
         });
       } catch (err) {
-        cb(prependFilenameToError(filename, err))
+        cb(prependFilenameToError(filename, err));
       }
     });
   }
 
   // render with a layout
   function render_with_layout (filename, template, locals, cb) {
-    render_file(locals, function(err, str) {
+    render_file(locals, function (err, str) {
       if (err) {
         return cb(err);
       }
@@ -114,16 +138,17 @@ function middleware(filename, options, cb) {
       locals.body = str;
 
       try {
-        let res = template(locals, handlebarsOpts)
-        self.async.done(function (values) {
-          Object.keys(values).forEach(function (id) {
-            res = res.replace(id, values[id])
-          })
+        const res = template(locals, handlebarsOpts);
 
-          cb(null, res)
-        })
+        // Handle async operations for layout
+        processAsyncResults(res, function (err, processedRes) {
+          if (err) {
+            return cb(prependFilenameToError(filename, err));
+          }
+          cb(null, processedRes);
+        });
       } catch (err) {
-        cb(prependFilenameToError(filename, err))
+        cb(prependFilenameToError(filename, err));
       }
     });
   }
@@ -156,22 +181,20 @@ function middleware(filename, options, cb) {
   });
 
   for (let i = 0; i < layout_filename.length; i++) {
-    const layout_template = cache[layout_filename[i]]
+    const layout_template = cache[layout_filename[i]];
 
     if (layout_template) {
       return render_with_layout(layout_filename[i], layout_template, options, cb)
     }
   }
 
-  // TODO check if layout path has .hbs extension
-
-  function prependFilenameToError (filename, err) {
+  function prependFilenameToError(filename, err) {
     // prepend to the message
     if (typeof err.message === 'string') {
-      err.message = filename + ': ' + err.message
+      err.message = filename + ': ' + err.message;
     }
 
-    return err
+    return err;
   }
 
   function cacheAndCompile(filename, str) {
@@ -180,13 +203,13 @@ function middleware(filename, options, cb) {
       cache[filename] = layout_template;
     }
 
-    render_with_layout(filename, layout_template, options, cb)
+    render_with_layout(filename, layout_template, options, cb);
   }
 
   function tryReadFileAndCache(templates) {
     const template = templates.shift();
 
-    fs.readFile(template, 'utf8', function(err, str) {
+    fs.readFile(template, 'utf8', function (err, str) {
       if (err) {
         if (layout && templates.length === 0) {
           // Only return error if user explicitly asked for layout.
@@ -232,84 +255,89 @@ Instance.prototype.registerPartial = function () {
 };
 
 Instance.prototype.registerPartials = function (directory, options, done) {
-  const self = this
+  const self = this;
 
   if (this._queue) {
-    self._queue.unshift(self.registerPartials.bind.apply(self.registerPartials,
-      [this].concat(Array.prototype.slice.call(arguments))))
-    return
+    self._queue.unshift(
+      self.registerPartials.bind.apply(
+        self.registerPartials,
+        [this].concat(Array.prototype.slice.call(arguments))
+      )
+    );
+    return;
   } else {
-    self._queue = []
+    self._queue = [];
   }
 
-  let callback
-  const handlebars = self.handlebars
-  let opts = options || {}
+  let callback;
+  const handlebars = self.handlebars;
+  let opts = options || {};
 
   if (done || typeof options !== 'function') {
-    callback = done
+    callback = done;
   } else {
-    callback = options
-    opts = {}
+    callback = options;
+    opts = {};
   }
 
   const rename = opts.rename !== undefined ? opts.rename : function (name) {
     return name.replace(/\-/g, '_')
   }
 
-  const w = walk(directory)
+  const w = walk(directory);
   w.on('file', function (root, stat, done) {
-    const filepath = path.join(root, stat.name)
+    const filepath = path.join(root, stat.name);
     const isValidTemplate = /\.(html|hbs)$/.test(filepath);
 
     if (!isValidTemplate) {
       return done(null);
     }
 
-    fs.readFile(filepath, 'utf8', function(err, data) {
+    fs.readFile(filepath, 'utf8', function (err, data) {
       if (!err) {
-        const extname = path.extname(filepath)
+        const extname = path.extname(filepath);
         const name = path.relative(directory, filepath)
           .slice(0, -(extname.length))
-          .replace(/\\/g, '/')
+          .replace(/\\/g, '/');
 
-        handlebars.registerPartial(rename(name).replace(/ /g, '_'), data)
+        handlebars.registerPartial(rename(name).replace(/ /g, '_'), data);
       }
 
       done(err);
     });
-  })
+  });
   w.on('end', function () {
     if (self._queue) {
-      const q = self._queue
+      const q = self._queue;
 
-      self._queue = null
+      self._queue = null;
 
       for (let i = 0; i < q.length; i++) {
-        q[i]()
+        q[i]();
       }
     }
-  })
+  });
 
   if (callback) {
-    w.on('end', callback)
+    w.on('end', callback);
   }
 };
 
-Instance.prototype.registerAsyncHelper = function(name, fn) {
+Instance.prototype.registerAsyncHelper = function (name, fn) {
   const self = this;
-  self.handlebars.registerHelper(name, function() {
-    return self.async.resolve(fn.bind(this), arguments)
+  self.handlebars.registerHelper(name, function () {
+    const args = Array.prototype.slice.call(arguments);
+    return self.async.resolve.apply(self.async, [fn.bind(this)].concat(args));
   });
 };
 
-Instance.prototype.localsAsTemplateData = function(app) {
+Instance.prototype.localsAsTemplateData = function (app) {
   // Set a flag to indicate we should pass locals as data
   this.__localsAsData = true;
 
-  app.render = (function(render) {
-    return function(view, options, callback) {
-      if (typeof options === "function") {
+  app.render = (function (render) {
+    return function (view, options, callback) {
+      if (typeof options === 'function') {
         callback = options;
         options = {};
       }
@@ -326,6 +354,6 @@ Instance.prototype.localsAsTemplateData = function(app) {
 };
 
 module.exports = new Instance();
-module.exports.create = function(handlebars) {
+module.exports.create = function (handlebars) {
   return new Instance(handlebars);
 };

--- a/lib/hbs.js
+++ b/lib/hbs.js
@@ -1,8 +1,8 @@
-var fs = require('fs');
-var path = require('path');
-var walk = require('walk').walk;
+const fs = require('fs');
+const path = require('path');
+const walk = require('walk').walk;
 
-var async = require('./async');
+const async = require('./async');
 
 function Instance(handlebars) {
   if (!(this instanceof Instance)) {
@@ -11,7 +11,7 @@ function Instance(handlebars) {
 
   // expose handlebars, allows users to use their versions
   // by overriding this early in their apps
-  var self = this;
+  const self = this;
 
   self.handlebars = handlebars || require('handlebars').create();
 
@@ -30,24 +30,24 @@ function Instance(handlebars) {
 
 // express 3.x template engine compliance
 function middleware(filename, options, cb) {
-  var self = this;
+  const self = this;
 
   if (self._queue) {
     self._queue.push(middleware.bind.apply(middleware, [this].concat(Array.prototype.slice.call(arguments))))
     return
   }
 
-  var cache = self.cache;
-  var handlebars = self.handlebars;
+  const cache = self.cache;
+  const handlebars = self.handlebars;
 
   self.async = async();
 
   // grab extension from filename
   // if we need a layout, we will look for one matching out extension
-  var extension = path.extname(filename);
+  const extension = path.extname(filename);
 
   // Default handlebars runtime options
-  var handlebarsOpts = {
+  const handlebarsOpts = {
     allowProtoMethodsByDefault: true,
     allowProtoPropertiesByDefault: true
   }
@@ -61,10 +61,10 @@ function middleware(filename, options, cb) {
   // cb(err, str)
   function render_file(locals, cb) {
     // cached?
-    var template = cache[filename];
+    const template = cache[filename];
     if (template) {
       try {
-        var res = template(locals, handlebarsOpts)
+        let res = template(locals, handlebarsOpts)
         self.async.done(function (values) {
           Object.keys(values).forEach(function (id) {
             res = res.replace(id, values[id])
@@ -84,13 +84,13 @@ function middleware(filename, options, cb) {
         return cb(err);
       }
 
-      var template = handlebars.compile(str);
+      const template = handlebars.compile(str);
       if (locals.cache) {
         cache[filename] = template;
       }
 
       try {
-        var res = template(locals, handlebarsOpts);
+        let res = template(locals, handlebarsOpts);
         self.async.done(function(values) {
           Object.keys(values).forEach(function(id) {
             res = res.replace(id, values[id]);
@@ -114,7 +114,7 @@ function middleware(filename, options, cb) {
       locals.body = str;
 
       try {
-        var res = template(locals, handlebarsOpts)
+        let res = template(locals, handlebarsOpts)
         self.async.done(function (values) {
           Object.keys(values).forEach(function (id) {
             res = res.replace(id, values[id])
@@ -128,7 +128,7 @@ function middleware(filename, options, cb) {
     });
   }
 
-  var layout = options.layout;
+  let layout = options.layout;
 
   // user did not specify a layout in the locals
   // check global layout state
@@ -143,10 +143,10 @@ function middleware(filename, options, cb) {
     return render_file(options, cb);
   }
 
-  var view_dirs = options.settings.views;
+  const view_dirs = options.settings.views;
 
-  var layout_filename = [].concat(view_dirs).map(function (view_dir) {
-    var view_path = path.join(view_dir, layout || 'layout');
+  const layout_filename = [].concat(view_dirs).map(function (view_dir) {
+    let view_path = path.join(view_dir, layout || 'layout');
 
     if (!path.extname(view_path)) {
       view_path += extension;
@@ -155,8 +155,8 @@ function middleware(filename, options, cb) {
     return view_path;
   });
 
-  for (var i = 0; i < layout_filename.length; i++) {
-    var layout_template = cache[layout_filename[i]]
+  for (let i = 0; i < layout_filename.length; i++) {
+    const layout_template = cache[layout_filename[i]]
 
     if (layout_template) {
       return render_with_layout(layout_filename[i], layout_template, options, cb)
@@ -175,7 +175,7 @@ function middleware(filename, options, cb) {
   }
 
   function cacheAndCompile(filename, str) {
-    var layout_template = handlebars.compile(str);
+    const layout_template = handlebars.compile(str);
     if (options.cache) {
       cache[filename] = layout_template;
     }
@@ -184,7 +184,7 @@ function middleware(filename, options, cb) {
   }
 
   function tryReadFileAndCache(templates) {
-    var template = templates.shift();
+    const template = templates.shift();
 
     fs.readFile(template, 'utf8', function(err, str) {
       if (err) {
@@ -213,7 +213,7 @@ Instance.prototype.compile = function (str) {
     return str;
   }
 
-  var template = this.handlebars.compile(str);
+  const template = this.handlebars.compile(str);
   return function (locals) {
     return template(locals, {
       helpers: locals.blockHelpers,
@@ -232,7 +232,7 @@ Instance.prototype.registerPartial = function () {
 };
 
 Instance.prototype.registerPartials = function (directory, options, done) {
-  var self = this
+  const self = this
 
   if (this._queue) {
     self._queue.unshift(self.registerPartials.bind.apply(self.registerPartials,
@@ -242,9 +242,9 @@ Instance.prototype.registerPartials = function (directory, options, done) {
     self._queue = []
   }
 
-  var callback
-  var handlebars = self.handlebars
-  var opts = options || {}
+  let callback
+  const handlebars = self.handlebars
+  let opts = options || {}
 
   if (done || typeof options !== 'function') {
     callback = done
@@ -253,14 +253,14 @@ Instance.prototype.registerPartials = function (directory, options, done) {
     opts = {}
   }
 
-  var rename = opts.rename !== undefined ? opts.rename : function (name) {
+  const rename = opts.rename !== undefined ? opts.rename : function (name) {
     return name.replace(/\-/g, '_')
   }
 
-  var w = walk(directory)
+  const w = walk(directory)
   w.on('file', function (root, stat, done) {
-    var filepath = path.join(root, stat.name)
-    var isValidTemplate = /\.(html|hbs)$/.test(filepath);
+    const filepath = path.join(root, stat.name)
+    const isValidTemplate = /\.(html|hbs)$/.test(filepath);
 
     if (!isValidTemplate) {
       return done(null);
@@ -268,8 +268,8 @@ Instance.prototype.registerPartials = function (directory, options, done) {
 
     fs.readFile(filepath, 'utf8', function(err, data) {
       if (!err) {
-        var extname = path.extname(filepath)
-        var name = path.relative(directory, filepath)
+        const extname = path.extname(filepath)
+        const name = path.relative(directory, filepath)
           .slice(0, -(extname.length))
           .replace(/\\/g, '/')
 
@@ -281,11 +281,11 @@ Instance.prototype.registerPartials = function (directory, options, done) {
   })
   w.on('end', function () {
     if (self._queue) {
-      var q = self._queue
+      const q = self._queue
 
       self._queue = null
 
-      for (var i = 0; i < q.length; i++) {
+      for (let i = 0; i < q.length; i++) {
         q[i]()
       }
     }
@@ -297,7 +297,7 @@ Instance.prototype.registerPartials = function (directory, options, done) {
 };
 
 Instance.prototype.registerAsyncHelper = function(name, fn) {
-  var self = this;
+  const self = this;
   self.handlebars.registerHelper(name, function() {
     return self.async.resolve(fn.bind(this), arguments)
   });
@@ -316,7 +316,7 @@ Instance.prototype.localsAsTemplateData = function(app) {
 
       // Mix response.locals (options._locals) with app.locals (this.locals)
       options._locals = options._locals || {};
-      for (var key in this.locals) {
+      for (let key in this.locals) {
         options._locals[key] = this.locals[key];
       }
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,10 @@
     "walk": "2.3.15"
   },
   "devDependencies": {
-    "mocha": "6.2.2",
+    "eslint": "7.32.0",
+    "eslint-plugin-markdown": "2.2.1",
+    "mocha": "9.2.2",
+    "nyc": "15.1.0",
     "rimraf": "2.7.1",
     "supertest": "6.1.6"
   },

--- a/package.json
+++ b/package.json
@@ -14,10 +14,7 @@
     "walk": "2.3.15"
   },
   "devDependencies": {
-    "eslint": "7.32.0",
-    "eslint-plugin-markdown": "2.2.1",
-    "mocha": "9.2.2",
-    "nyc": "15.1.0",
+    "mocha": "6.2.2",
     "rimraf": "2.7.1",
     "supertest": "6.1.6"
   },

--- a/test/3.x/app.js
+++ b/test/3.x/app.js
@@ -1,15 +1,15 @@
-var path = require('path')
-var request = require('supertest')
-var utils = require('../support/utils')
+const path = require('path')
+const request = require('supertest')
+const utils = require('../support/utils')
 
-var FIXTURES_DIR = path.join(__dirname, '..', 'fixtures')
+const FIXTURES_DIR = path.join(__dirname, '..', 'fixtures')
 
 // builtin
-var fs = require('fs');
-var assert = require('assert');
+const fs = require('fs');
+const assert = require('assert');
 
 // local
-var hbs = require('../../').create();
+const hbs = require('../../').create();
 
 hbs.registerHelper('make_error', function () {
   throw new TypeError('oops!')
@@ -24,9 +24,9 @@ hbs.registerHelper('link_to2', function(title, context) {
 });
 
 hbs.registerHelper('list', function(items, context) {
-  var out = '<ul class="' + (this.listClassName || '') + '">'
+  let out = '<ul class="' + (this.listClassName || '') + '">'
 
-  for(var i=0; i<items.length; ++i) {
+  for(let i=0; i<items.length; ++i) {
     out = out + "<li>" + context.fn(items[i]) + "</li>";
   }
   return out + "</ul>";
@@ -35,7 +35,7 @@ hbs.registerHelper('list', function(items, context) {
 hbs.registerPartial('link2', '<a href="/people/{{id}}">{{name}}</a>');
 hbs.registerPartials(path.join(__dirname, 'views', 'partials'))
 
-var app = null
+let app = null
 
 before(function () {
   if (utils.nodeVersionCompare(10.0) >= 0) {
@@ -43,7 +43,7 @@ before(function () {
     return
   }
 
-  var express = require('express')
+  const express = require('express')
 
   app = express()
 

--- a/test/3.x/async_helpers.js
+++ b/test/3.x/async_helpers.js
@@ -1,13 +1,13 @@
-var path = require('path')
-var request = require('supertest')
-var utils = require('../support/utils')
+const path = require('path')
+const request = require('supertest')
+const utils = require('../support/utils')
 
-var FIXTURES_DIR = path.join(__dirname, '..', 'fixtures')
+const FIXTURES_DIR = path.join(__dirname, '..', 'fixtures')
 
 // builtin
-var fs = require('fs');
+const fs = require('fs');
 
-var app = null
+let app = null
 
 suite('express 3.x async helpers')
 
@@ -17,8 +17,8 @@ before(function () {
     return
   }
 
-  var express = require('express')
-  var hbs = require('../../').create()
+  const express = require('express')
+  const hbs = require('../../').create()
 
   app = express()
 
@@ -34,9 +34,9 @@ before(function () {
 
   // value for async helper
   // it will be called a few times from the template
-  var vals = ['foo', 'bar', 'baz']
+  const vals = ['foo', 'bar', 'baz']
   hbs.registerAsyncHelper('async', function (context, cb) {
-    var prefix = this.prefix || ''
+    const prefix = this.prefix || ''
 
     process.nextTick(function () {
       cb(prefix + vals.shift())
@@ -45,9 +45,9 @@ before(function () {
 
   // fake async helper, returns immediately
   // although a regular helper could have been used we should support this use case
-  var count = 0
+  let count = 0
   hbs.registerAsyncHelper('fake-async', function (context, cb) {
-    var val = 'instant' + count++
+    const val = 'instant' + count++
     cb(val)
   })
 

--- a/test/3.x/index.js
+++ b/test/3.x/index.js
@@ -1,7 +1,7 @@
-var exec = require('child_process').exec
-var path = require('path')
-var rimraf = require('rimraf')
-var utils = require('../support/utils')
+const exec = require('child_process').exec
+const path = require('path')
+const rimraf = require('rimraf')
+const utils = require('../support/utils')
 
 suite('express 3.x')
 
@@ -11,7 +11,7 @@ before(function (done) {
     return done()
   }
 
-  var env = utils.childEnvironment()
+  const env = utils.childEnvironment()
 
   this.timeout(30000)
   exec('npm install --prefix . express@~3.16.8', { cwd: __dirname, env: env }, function (err, stderr) {

--- a/test/3.x/no_layout_app.js
+++ b/test/3.x/no_layout_app.js
@@ -1,14 +1,14 @@
-var path = require('path')
-var request = require('supertest')
-var utils = require('../support/utils')
+const path = require('path')
+const request = require('supertest')
+const utils = require('../support/utils')
 
-var FIXTURES_DIR = path.join(__dirname, '..', 'fixtures')
+const FIXTURES_DIR = path.join(__dirname, '..', 'fixtures')
 
 // builtin
-var fs = require('fs');
-var root = process.cwd();
+const fs = require('fs');
+const root = process.cwd();
 
-var app = null
+let app = null
 
 suite('express 3.x no layout')
 
@@ -18,8 +18,8 @@ before(function () {
     return
   }
 
-  var express = require('express')
-  var hbs = require('../../')
+  const express = require('express')
+  const hbs = require('../../')
 
   app = express()
 
@@ -57,7 +57,7 @@ before(function () {
       title: 'Express Handlebars Test'
     }, function (error, body) {
       if (error) return next(error)
-      var file = path.join(root, 'test', '3.x', 'views', 'layout.hbs')
+      const file = path.join(root, 'test', '3.x', 'views', 'layout.hbs')
       if (hbs.cache[file]) {
         res.send(body)
       } else {

--- a/test/3.x/view_engine.js
+++ b/test/3.x/view_engine.js
@@ -1,13 +1,13 @@
-var path = require('path')
-var request = require('supertest')
-var utils = require('../support/utils')
+const path = require('path')
+const request = require('supertest')
+const utils = require('../support/utils')
 
-var FIXTURES_DIR = path.join(__dirname, '..', 'fixtures')
+const FIXTURES_DIR = path.join(__dirname, '..', 'fixtures')
 
 // builtin
-var fs = require('fs');
+const fs = require('fs');
 
-var app = null
+let app = null
 
 suite('express 3.x view engine')
 
@@ -17,8 +17,8 @@ before(function () {
     return
   }
 
-  var express = require('express')
-  var hbs = require('../../')
+  const express = require('express')
+  const hbs = require('../../')
 
   app = express()
 

--- a/test/4.x/app.js
+++ b/test/4.x/app.js
@@ -1,15 +1,15 @@
-var path = require('path')
-var request = require('supertest')
-var utils = require('../support/utils')
+const path = require('path')
+const request = require('supertest')
+const utils = require('../support/utils')
 
-var FIXTURES_DIR = path.join(__dirname, '..', 'fixtures')
+const FIXTURES_DIR = path.join(__dirname, '..', 'fixtures')
 
 // builtin
-var fs = require('fs');
-var assert = require('assert');
+const fs = require('fs');
+const assert = require('assert');
 
 // local
-var hbs = require('../../').create();
+const hbs = require('../../').create();
 
 hbs.registerHelper('make_error', function () {
   throw new TypeError('oops!')
@@ -24,9 +24,9 @@ hbs.registerHelper('link_to2', function(title, context) {
 });
 
 hbs.registerHelper('list', function(items, context) {
-  var out = '<ul class="' + (this.listClassName || '') + '">'
+  let out = '<ul class="' + (this.listClassName || '') + '">'
 
-  for(var i=0; i<items.length; ++i) {
+  for(let i=0; i<items.length; ++i) {
     out = out + "<li>" + context.fn(items[i]) + "</li>";
   }
   return out + "</ul>";
@@ -35,7 +35,7 @@ hbs.registerHelper('list', function(items, context) {
 hbs.registerPartial('link2', '<a href="/people/{{id}}">{{name}}</a>');
 hbs.registerPartials(path.join(__dirname, 'views', 'partials'))
 
-var app = null
+let app = null
 
 before(function () {
   if (utils.nodeVersionCompare(0.10) < 0) {
@@ -43,7 +43,7 @@ before(function () {
     return
   }
 
-  var express = require('express')
+  const express = require('express')
 
   app = express()
 

--- a/test/4.x/async_helpers.js
+++ b/test/4.x/async_helpers.js
@@ -1,13 +1,13 @@
-var path = require('path')
-var request = require('supertest')
-var utils = require('../support/utils')
+const path = require('path')
+const request = require('supertest')
+const utils = require('../support/utils')
 
-var FIXTURES_DIR = path.join(__dirname, '..', 'fixtures')
+const FIXTURES_DIR = path.join(__dirname, '..', 'fixtures')
 
 // builtin
-var fs = require('fs');
+const fs = require('fs');
 
-var app = null
+let app = null
 
 suite('express 4.x async helpers')
 
@@ -17,8 +17,8 @@ before(function () {
     return
   }
 
-  var express = require('express')
-  var hbs = require('../../').create()
+  const express = require('express')
+  const hbs = require('../../').create()
 
   app = express()
 
@@ -35,10 +35,10 @@ before(function () {
 
   // value for async helper
   // it will be called a few times from the template
-  var indx = 0
-  var vals = ['foo', 'bar', 'baz']
+  let indx = 0
+  const vals = ['foo', 'bar', 'baz']
   hbs.registerAsyncHelper('async', function (context, cb) {
-    var prefix = this.prefix || ''
+    const prefix = this.prefix || ''
 
     process.nextTick(function () {
       cb(prefix + vals[indx++ % 3])
@@ -53,16 +53,16 @@ before(function () {
 
   hbs.registerAsyncHelper('async-with-params', function (a, b, ctx, cb) {
     process.nextTick(function () {
-      var val = a + b
+      const val = a + b
       cb(val)
     })
   })
 
   // fake async helper, returns immediately
   // although a regular helper could have been used we should support this use case
-  var count = 0
+  let count = 0
   hbs.registerAsyncHelper('fake-async', function (context, cb) {
-    var val = 'instant' + count++
+    const val = 'instant' + count++
     cb(val)
   })
 

--- a/test/4.x/index.js
+++ b/test/4.x/index.js
@@ -1,7 +1,7 @@
-var exec = require('child_process').exec
-var path = require('path')
-var rimraf = require('rimraf')
-var utils = require('../support/utils')
+const exec = require('child_process').exec
+const path = require('path')
+const rimraf = require('rimraf')
+const utils = require('../support/utils')
 
 suite('express 4.x')
 
@@ -11,7 +11,7 @@ before(function (done) {
     return done()
   }
 
-  var env = utils.childEnvironment()
+  const env = utils.childEnvironment()
 
   this.timeout(30000)
   exec('npm install --prefix . express@~4.17.1', { cwd: __dirname, env: env }, function (err, stderr) {

--- a/test/4.x/no_layout_app.js
+++ b/test/4.x/no_layout_app.js
@@ -1,14 +1,14 @@
-var path = require('path')
-var request = require('supertest')
-var utils = require('../support/utils')
+const path = require('path')
+const request = require('supertest')
+const utils = require('../support/utils')
 
-var FIXTURES_DIR = path.join(__dirname, '..', 'fixtures')
+const FIXTURES_DIR = path.join(__dirname, '..', 'fixtures')
 
 // builtin
-var fs = require('fs');
-var root = process.cwd();
+const fs = require('fs');
+const root = process.cwd();
 
-var app = null
+let app = null
 
 suite('express 4.x no layout')
 
@@ -18,8 +18,8 @@ before(function () {
     return
   }
 
-  var express = require('express')
-  var hbs = require('../../')
+  const express = require('express')
+  const hbs = require('../../')
 
   app = express()
 
@@ -59,7 +59,7 @@ before(function () {
       title: 'Express Handlebars Test'
     }, function(error, body){
       if (error) return next(error)
-      var file = path.join(root, 'test', '4.x', 'views', 'layout.hbs')
+      const file = path.join(root, 'test', '4.x', 'views', 'layout.hbs')
       if (hbs.cache[file]) {
         res.send(body)
       } else {

--- a/test/4.x/register_partials.js
+++ b/test/4.x/register_partials.js
@@ -1,6 +1,6 @@
-var path = require('path')
-var request = require('supertest')
-var utils = require('../support/utils')
+const path = require('path')
+const request = require('supertest')
+const utils = require('../support/utils')
 
 before(function () {
   if (utils.nodeVersionCompare(0.10) < 0) {
@@ -9,9 +9,9 @@ before(function () {
 })
 
 test('render waits on register partials', function (done) {
-  var express = require('express')
-  var app = express()
-  var hbs = require('../../').create()
+  const express = require('express')
+  const app = express()
+  const hbs = require('../../').create()
 
   app.engine('hbs', hbs.__express)
   app.engine('html', hbs.__express)
@@ -30,9 +30,9 @@ test('render waits on register partials', function (done) {
 })
 
 test('render waits on multiple register partials', function (done) {
-  var express = require('express')
-  var app = express()
-  var hbs = require('../../').create()
+  const express = require('express')
+  const app = express()
+  const hbs = require('../../').create()
 
   app.engine('hbs', hbs.__express)
   app.engine('html', hbs.__express)
@@ -52,15 +52,15 @@ test('render waits on multiple register partials', function (done) {
 })
 
 test('register partials callback', function (done) {
-  var hbs = require('../../').create()
+  const hbs = require('../../').create()
 
   hbs.registerPartials(path.join(__dirname, 'views', 'partials'), done)
 })
 
 test('register partials name', function (done) {
-  var express = require('express')
-  var app = express()
-  var hbs = require('../../').create()
+  const express = require('express')
+  const app = express()
+  const hbs = require('../../').create()
 
   hbs.registerPartials(path.join(__dirname, 'views', 'partials'), {
     rename: function (name) { return name.replace(/(^|\s)(\w)/g, function (s, p, c) { return p + c.toUpperCase() }) }

--- a/test/4.x/view_engine.js
+++ b/test/4.x/view_engine.js
@@ -1,13 +1,13 @@
-var path = require('path')
-var request = require('supertest')
-var utils = require('../support/utils')
+const path = require('path')
+const request = require('supertest')
+const utils = require('../support/utils')
 
-var FIXTURES_DIR = path.join(__dirname, '..', 'fixtures')
+const FIXTURES_DIR = path.join(__dirname, '..', 'fixtures')
 
 // builtin
-var fs = require('fs');
+const fs = require('fs');
 
-var app = null
+let app = null
 
 suite('express 4.x view engine')
 
@@ -17,8 +17,8 @@ before(function () {
     return
   }
 
-  var express = require('express')
-  var hbs = require('../../')
+  const express = require('express')
+  const hbs = require('../../')
 
   app = express()
 

--- a/test/support/utils.js
+++ b/test/support/utils.js
@@ -4,10 +4,10 @@ module.exports.childEnvironment = childEnvironment
 module.exports.nodeVersionCompare = nodeVersionCompare
 
 function childEnvironment () {
-  var env = Object.create(null)
+  const env = Object.create(null)
 
   // copy the environment except for npm veriables
-  for (var key in process.env) {
+  for (const key in process.env) {
     if (key.substr(0, 4) !== 'npm_') {
       env[key] = process.env[key]
     }


### PR DESCRIPTION
This PR adds a bunch of changes to the core `lib` files but basically does 2 things asked for in #203:

- [x] Drops support for Node.js below 4
- [x] Add promise support to async helpers

it also makes the code `es6` compliant.

I've intentionally not touched any tests and not changed anything in the intended behavior of the library.