### PR TITLE
chore(ci/cd): add newer node versions to test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
         - Node.js 22.x
         - Node.js 23.x
         - Node.js 24.x
+        - Node.js 25.x
 
         include:
         - name: Node.js 6.x
@@ -80,6 +81,9 @@ jobs:
 
         - name: Node.js 24.x
           node-version: "24"
+
+        - name: Node.js 25.x
+          node-version: "25"
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
This PR adds newer versions of Node to the test matrix to ensure compatibility ahead of the `5.0` release.